### PR TITLE
Draft: Fix Issue #2

### DIFF
--- a/lib/page/home/home_page.dart
+++ b/lib/page/home/home_page.dart
@@ -37,38 +37,41 @@ class HomePage extends ConsumerWidget {
     final PersistentTabController _controller =
         ref.read(displayPageSelectorProvider.notifier).state;
 
-    return PersistentTabView(
-      context,
-      controller: _controller,
-      screens: _buildScreens(),
-      items: _navBarsItems(context),
-      confineInSafeArea: true,
-      backgroundColor: Colors.white, // Default is Colors.white.
-      handleAndroidBackButtonPress: true, // Default is true.
-      resizeToAvoidBottomInset:
-          true, // This needs to be true if you want to move up the screen when keyboard appears. Default is true.
-      stateManagement: true, // Default is true.
-      hideNavigationBarWhenKeyboardShows:
-          true, // Recommended to set 'resizeToAvoidBottomInset' as true while using this argument. Default is true.
-      decoration: NavBarDecoration(
-        borderRadius: BorderRadius.circular(10.0),
-        colorBehindNavBar: Colors.white,
+    return WillPopScope(
+      onWillPop: () async => false,
+      child: PersistentTabView(
+        context,
+        controller: _controller,
+        screens: _buildScreens(),
+        items: _navBarsItems(context),
+        confineInSafeArea: true,
+        backgroundColor: Colors.white, // Default is Colors.white.
+        handleAndroidBackButtonPress: true, // Default is true.
+        resizeToAvoidBottomInset:
+            true, // This needs to be true if you want to move up the screen when keyboard appears. Default is true.
+        stateManagement: true, // Default is true.
+        hideNavigationBarWhenKeyboardShows:
+            true, // Recommended to set 'resizeToAvoidBottomInset' as true while using this argument. Default is true.
+        decoration: NavBarDecoration(
+          borderRadius: BorderRadius.circular(10.0),
+          colorBehindNavBar: Colors.white,
+        ),
+        popAllScreensOnTapOfSelectedTab: true,
+        popActionScreens: PopActionScreensType.all,
+        itemAnimationProperties: const ItemAnimationProperties(
+          // Navigation Bar's items animation properties.
+          duration: Duration(milliseconds: 200),
+          curve: Curves.ease,
+        ),
+        screenTransitionAnimation: const ScreenTransitionAnimation(
+          // Screen transition animation on change of selected tab.
+          animateTabTransition: true,
+          curve: Curves.ease,
+          duration: Duration(milliseconds: 200),
+        ),
+        navBarStyle:
+            NavBarStyle.style3, // Choose the nav bar style with this property.
       ),
-      popAllScreensOnTapOfSelectedTab: true,
-      popActionScreens: PopActionScreensType.all,
-      itemAnimationProperties: const ItemAnimationProperties(
-        // Navigation Bar's items animation properties.
-        duration: Duration(milliseconds: 200),
-        curve: Curves.ease,
-      ),
-      screenTransitionAnimation: const ScreenTransitionAnimation(
-        // Screen transition animation on change of selected tab.
-        animateTabTransition: true,
-        curve: Curves.ease,
-        duration: Duration(milliseconds: 200),
-      ),
-      navBarStyle:
-          NavBarStyle.style3, // Choose the nav bar style with this property.
     );
   }
 }

--- a/lib/page/task_list/task/recommendation_task_type_input_form.dart
+++ b/lib/page/task_list/task/recommendation_task_type_input_form.dart
@@ -24,34 +24,51 @@ class RecommendationTaskTypeInputForm extends HookConsumerWidget {
     final showRecommedationList = useState<bool>(false);
     final selectedTaskType = ref.watch(selectedTaskTypeProvider);
 
-    return Column(
-      children: [
-        ListTile(
-          title: TextFormField(
-              decoration: const InputDecoration(hintText: '種類を選択してください'),
-              initialValue: input.value ?? selectedTaskType?.name,
-              onChanged: (value) {
-                input.value = value;
+    // TaskTypeが選択されていないときは入力フォームを表示する
+    if (selectedTaskType == null) {
+      return Column(
+        children: [
+          ListTile(
+            title: TextFormField(
+                decoration: const InputDecoration(hintText: '種類を選択してください'),
+                initialValue: input.value ?? selectedTaskType?.name,
+                onChanged: (value) {
+                  input.value = value;
+                },
+                onTap: () {
+                  showRecommedationList.value = !showRecommedationList.value;
+                }),
+            trailing: IconButton(
+              onPressed: () {
+                input.value = null;
+                showRecommedationList.value = false;
+                ref
+                    .read(selectedTaskTypeProvider.notifier)
+                    .update((state) => null);
               },
-              onTap: () {
-                showRecommedationList.value = !showRecommedationList.value;
-              }),
-          trailing: IconButton(
-            onPressed: () {
-              input.value = null;
-              showRecommedationList.value = false;
-              ref
-                  .read(selectedTaskTypeProvider.notifier)
-                  .update((state) => null);
-            },
-            icon: const Icon(Icons.cancel_outlined),
+              icon: const Icon(Icons.cancel_outlined),
+            ),
           ),
-        ),
-        RecommendationListView(
-          input: input,
-          visible: showRecommedationList,
-        ),
-      ],
+          RecommendationListView(
+            input: input,
+            visible: showRecommedationList,
+          ),
+        ],
+      );
+    }
+
+    // TaskTypeが選択されているときは選択したTaskTypeの名前を表示する
+    return ListTile(
+      title: Text(selectedTaskType.name),
+      trailing: IconButton(
+        // 初期化処理
+        onPressed: () {
+          input.value = null;
+          showRecommedationList.value = false;
+          ref.read(selectedTaskTypeProvider.notifier).update((state) => null);
+        },
+        icon: const Icon(Icons.cancel_outlined),
+      ),
     );
   }
 }

--- a/lib/page/task_list/task/recommendation_task_type_input_form.dart
+++ b/lib/page/task_list/task/recommendation_task_type_input_form.dart
@@ -23,18 +23,13 @@ class RecommendationTaskTypeInputForm extends HookConsumerWidget {
     final ValueNotifier<String?> input = useState<String?>(null);
     final showRecommedationList = useState<bool>(false);
     final selectedTaskType = ref.watch(selectedTaskTypeProvider);
-    final TextEditingController controller = TextEditingController();
-
-    controller.text = input.value ?? selectedTaskType?.name ?? '';
-    controller.selection = TextSelection.fromPosition(
-        TextPosition(offset: controller.text.length));
 
     return Column(
       children: [
         ListTile(
           title: TextFormField(
               decoration: const InputDecoration(hintText: '種類を選択してください'),
-              controller: controller,
+              initialValue: input.value ?? selectedTaskType?.name,
               onChanged: (value) {
                 input.value = value;
               },

--- a/lib/page/task_list/task/task_tile.dart
+++ b/lib/page/task_list/task/task_tile.dart
@@ -4,6 +4,7 @@ import 'package:imploop/domain/task.dart';
 import 'package:imploop/domain/todo.dart';
 import 'package:imploop/page/common/slidable_tile.dart';
 import 'package:imploop/page/task_list/task/task_edit_modal.dart';
+import 'package:imploop/page/task_list/task_list_page.dart';
 import 'package:imploop/page/task_list/todo/todo_create_modal.dart';
 import 'package:imploop/page/task_list/todo/todo_tile.dart';
 import 'package:imploop/service/task_service.dart';
@@ -74,8 +75,7 @@ class TaskTile extends HookWidget {
                       ),
                     ),
                   );
-                  // 前の画面に遷移
-                  Navigator.pop(context);
+                  TaskListPage.show(context);
                 }
               }
             }),


### PR DESCRIPTION
# 概要
TaskとTodoの種類を入力する際に、小文字・濁点の入力・変換ができない

# 不具合の再現方法
- Task一覧画面から＋ボタンを押下して、Task入力画面に遷移した後、プレースホルダーとして「種類を選択してください」と書かれた入力フォームに文字列を入力することで再現
> 種類を入力・選択するロジックはTaskとTodoで同じであるため、Todoの方の再現手順は確認していない

# 不具合が解消されたと判断する基準
以下の操作が行えるようになることが確認できたら、不具合が解消されたと判断する。
- [x] Task(Todo)の入力画面のTask(Todo)種類を選択する入力フォームで、「ばびぶべぼ」と入力できる
- [x] Task(Todo)の入力画面のTask(Todo)種類を選択する入力フォームで、「バビブベボ」と入力できる
- [x] Task(Todo)の入力画面のTask(Todo)種類を選択する入力フォームで、「ぱぴぷぺぽ」と入力できる
- [x] Task(Todo)の入力画面のTask(Todo)種類を選択する入力フォームで、「パピプペポ」と入力できる
- [x] Task(Todo)の入力画面のTask(Todo)種類を選択する入力フォームで、「春眠暁を覚えず」と入力できる

# 関連するIssue
https://github.com/TowaYamashita/imploop_production/issues/2
